### PR TITLE
Add pdf+zip mime type

### DIFF
--- a/src/flibustaOpdsApiHelper.ts
+++ b/src/flibustaOpdsApiHelper.ts
@@ -23,6 +23,7 @@ class FlibustaOpdsApiHelper {
     'application/rtf+zip',
     'application/txt+zip',
     'application/x-mobipocket-ebook',
+    'application/pdf+zip',
   ]);
 
   private static getAuthorsFromOpdsEntry(authors: OpdsEntryAuthor): Array<Author> {


### PR DESCRIPTION
`API` doesn't return download link for book like `361093` which has `pdf+zip` mime type.